### PR TITLE
Day 1: Trebuchet?! 

### DIFF
--- a/src/puzzles/2023/1.tsx
+++ b/src/puzzles/2023/1.tsx
@@ -1,24 +1,50 @@
 import { PuzzleForm, Solution } from "../PuzzleForm"
 import { sum } from "../helpers";
 
+const digitValues: Map<string, number> = new Map([
+    ['one', 1],
+    ['two', 2],
+    ['three', 3],
+    ['four', 4],
+    ['five', 5],
+    ['six', 6],
+    ['seven', 7],
+    ['eight', 8],
+    ['nine', 9]
+])
+
+const charValue = (digit: string): number => {
+    if (digitValues.has(digit)) {
+        return digitValues.get(digit) ?? 0;
+    }
+    return parseInt(digit);
+}
+
 const calibration: Solution = (input) => {
-    console.log(input);
     const lines = input.split('\n').map(line => {
         const relevant = line.replace(/[^0-9]/gu, '');
-        console.log(line);
         const firstChar = relevant[0];
         const lastChar = relevant[relevant.length-1];
-        const text = `${firstChar}${lastChar}`;
-        console.log(text);
-        console.log(relevant);
         return parseInt(`${firstChar}${lastChar}`);
     });
 
-    console.log(lines);
+    const partTwoLines = input.split('\n').map(line => {
+        const first = charValue(line.match(/[0-9]|(one|two|three|four|five|six|seven|eight|nine)/u)?.[0] ?? '0');
+        const last = [...line].reverse().join('').match(/[0-9]|(eno|owt|eerht|ruof|evif|xis|neves|thgie|enin)/u)?.[0] ?? '0';
+        const lastValue = charValue([...last].reverse().join(''));
+        return parseInt(`${first}${lastValue}`);
+    });
 
-    return (<div>
-        {sum(lines)}
-    </div>)
+    return (<>
+        <div>
+            Part One: 
+            {sum(lines)}
+        </div>
+        <div>
+            Part Two:
+            {sum(partTwoLines)}
+        </div>
+    </>)
 }
 
 export const Trebuchet = () => (

--- a/src/puzzles/2023/1.tsx
+++ b/src/puzzles/2023/1.tsx
@@ -1,0 +1,29 @@
+import { PuzzleForm, Solution } from "../PuzzleForm"
+import { sum } from "../helpers";
+
+const calibration: Solution = (input) => {
+    console.log(input);
+    const lines = input.split('\n').map(line => {
+        const relevant = line.replace(/[^0-9]/gu, '');
+        console.log(line);
+        const firstChar = relevant[0];
+        const lastChar = relevant[relevant.length-1];
+        const text = `${firstChar}${lastChar}`;
+        console.log(text);
+        console.log(relevant);
+        return parseInt(`${firstChar}${lastChar}`);
+    });
+
+    console.log(lines);
+
+    return (<div>
+        {sum(lines)}
+    </div>)
+}
+
+export const Trebuchet = () => (
+    <>
+        <h1>Day 1: Trebuchet?!</h1>
+        <PuzzleForm onSolve={calibration} />
+    </>
+)

--- a/src/puzzles/2023/puzzleIndex.tsx
+++ b/src/puzzles/2023/puzzleIndex.tsx
@@ -1,8 +1,13 @@
 import { Template } from "../Template";
+import { Trebuchet } from "./1";
 
 export const puzzleIndex = [
     {
         name: 'Sample Template',
         element: <Template />
+    },
+    {
+        name: 'Day 1: Trebuchet?!',
+        element: <Trebuchet />
     }
 ];


### PR DESCRIPTION
Aha... Isn't it too early in the day for regex?

Well, part one was no issue, I can match a digit character class as easy as you please, but part 2 had some certain... _complications_.

In particular, matching the 'compound digit names' caused a bit of a headache:

- `twone` being `21`
- `fiveight` being `58`
- `sevenine` being `79`
- `eightwo` being `82`
- ...you get the idea

Using simple matching you'd get the first entry but not the second. So how do you deal with this?

I'm sure that with the power of look-ahead matching you could do something clever so that the potentially connected characters (`e` in `one`, `o` in `two` etc.) could be matched without being consumed, that way you could get both.

But... Me being a lazy shlub and _knowing_ that I only need the first and last characters I decide to use a more _lateral_ approach.

We can consume the characters backwards without issue, right? Just need to flip the string and, uh, flip the regex that I use... I'm sure matching on `eno|owt|eerht|...` will make sense when I read it back in the future...

Well, if it works then it works! I might play about with the look-ahead if I have the time, see how hard it would be to match all the compound cases by making the last characters optional. It may work well or be confusing, senseless gibberish. We'll see!